### PR TITLE
Updated footer to match license

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer>
-  <p class="contained"><a href="https://github.com/netlify/netlify-cms/blob/master/LICENSE" class="text-link">Distributed under BSD License</a> · 
+  <p class="contained"><a href="https://github.com/netlify/netlify-cms/blob/master/LICENSE" class="text-link">Distributed under MIT License</a> · 
   <a href="https://github.com/netlify/netlify-cms/blob/master/CODE_OF_CONDUCT.md" class="text-link">Code of Conduct</a></p>
 </footer>
 


### PR DESCRIPTION
Netlify-CMS repo says it's MIT. This footer said it was BSD.