### PR TITLE
Match cms repo change: rename configuration.md to widgets.md

### DIFF
--- a/markdown.config.js
+++ b/markdown.config.js
@@ -13,7 +13,7 @@ const docFiles = [
   'intro.md',
   'quick-start.md',
   'validation.md',
-  'configuration.md',
+  'widgets.md',
   'contributor-guide.md',
   'customization.md',
   'test-drive.md'

--- a/site/content/docs/widgets.md
+++ b/site/content/docs/widgets.md
@@ -2,7 +2,7 @@
 title: Configuration
 position: 3
 ---
-<!-- AUTO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/netlify/netlify-cms/master/docs/configuration.md) -->
+<!-- AUTO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/netlify/netlify-cms/master/docs/widgets.md) -->
 # Configuring your site
 
 ## Widgets

--- a/site/content/docs/widgets.md
+++ b/site/content/docs/widgets.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration
+title: Widgets
 position: 3
 ---
 <!-- AUTO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/netlify/netlify-cms/master/docs/widgets.md) -->


### PR DESCRIPTION
Markdown magic can't automatically adapt to filename changes in the netlify-cms repo! Updating to match this PR: https://github.com/netlify/netlify-cms/pull/390

Will see how this goes in the preview.