### PR TITLE
Improve mobile functionality

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
   </head>
   <body>
-    <header id="header" {{ if or (eq .Section "docs") (eq .Title "Docs") }}class="scrolled"{{ end }}>
+    <header id="header" {{ if or (eq .Section "docs") (eq .Title "Docs") }}class="docs"{{ end }}>
       <div class="contained">
         <a href="/" class="logo"><img src="/img/netlify-cms-logo.svg"/></a>
         <a class="docs-link" href="/docs">Docs</a>

--- a/src/css/imports/docs.css
+++ b/src/css/imports/docs.css
@@ -1,6 +1,9 @@
 .docs.page {
-  padding: 157px $medium $xl $medium;
+  padding: 69px $medium $xl $medium;
   text-align: left;
+  @media screen and (min-width: $mobile) {
+    padding-top: 157px;
+  }
 
   .sidebar {
     @media screen and (min-width: $tablet) {

--- a/src/css/imports/docs.css
+++ b/src/css/imports/docs.css
@@ -1,8 +1,8 @@
 .docs.page {
-  padding: 69px $medium $xl $medium;
+  padding: 69px $tiny $xl;
   text-align: left;
   @media screen and (min-width: $mobile) {
-    padding-top: 157px;
+    padding: 157px $medium $xl;
   }
 
   .sidebar {
@@ -191,15 +191,14 @@
 		width: 100%;
 		text-align: left;
 		margin: 34px 0 $medium 0;
-		display: none;
-
-		@media screen and (min-width: $mobile) {
-			display: table;
-		}
 
 		th,
 		td {
-			padding: 0 $small;
+			padding: 0 $micro;
+
+      @media screen and (min-width: $mobile) {
+        padding: 0 $small;
+      }
 		}
 
 		th {
@@ -218,16 +217,6 @@
 		td {
 			font-size: 14px;
 			height: 46px;
-		}
-	}
-
-	.mobile-table-marker + table,
-	.mobile-table-marker + table + table,
-	.mobile-table-marker + table + table + table {
-		display: table;
-
-		@media screen and (min-width: $mobile) {
-			display: none;
 		}
 	}
 }

--- a/src/css/imports/header.css
+++ b/src/css/imports/header.css
@@ -86,7 +86,7 @@ header {
       display: none;
     }
 
-    a.github-btn {
+    .github-btn {
       display: none;
       @media screen and (min-width: $tablet) {
         display: inline-block;
@@ -94,7 +94,9 @@ header {
     }
 
     .utility-input {
-      display: inline;
+      @media screen and (min-width: $mobile) {
+        display: inline;
+      }
     }
   }
 

--- a/src/css/imports/header.css
+++ b/src/css/imports/header.css
@@ -77,8 +77,24 @@ header {
   &.docs {
     background: $darkGrey;
     padding: $small 0;
+
     @media screen and (max-width: $mobile) {
       position: static;
+    }
+
+    a.docs-link {
+      display: none;
+    }
+
+    a.github-btn {
+      display: none;
+      @media screen and (min-width: $tablet) {
+        display: inline-block;
+      }
+    }
+
+    .utility-input {
+      display: inline;
     }
   }
 
@@ -90,17 +106,7 @@ header {
     margin-left: $micro;
 
     &.docs-link {
-      display: none;
-
-      @media screen and (min-width: $tablet) {
-        display: initial;
-        -webkit-display: intial !important;
         margin-right: 12px;
-      }
-
-      @media screen and (min-width: 653px) {
-        margin: initial;
-      }
     }
   }
 
@@ -169,7 +175,7 @@ header {
     line-height: 24px;
     transition: all .2s ease-in-out;
 
-    @media screen and (min-width: 653px) {
+    @media screen and (min-width: $tablet) {
       display: inline;
     }
 

--- a/src/css/imports/header.css
+++ b/src/css/imports/header.css
@@ -74,6 +74,14 @@ header {
     }
   }
 
+  &.docs {
+    background: $darkGrey;
+    padding: $small 0;
+    @media screen and (max-width: $mobile) {
+      position: static;
+    }
+  }
+
   a {
     color: white;
     display: inline-block;


### PR DESCRIPTION
This breaks into three main changes:

**Fix header display on Docs pages**
* Add background color and spacing to match full-width style
* Fix style makes dropdown menu functional

**Change header link display to match page purpose**
* Display Docs link at all widths on Home page
* Remove Docs link from Docs pages
* Display Search box at all widths on Docs page
* Remove Search box at narrow widths on Home page
* Remove GitHub link at narrow widths on Docs page (Every docs page has an "Edit this page" link at the top that links to the repo.)

**Make tables visible at narrow widths**
* Previous styling called for double markup with separate mobile tables. Removed this and decreased padding instead.

I've tested on Chrome, Firefox, Safari, and Opera. I'll have to wait until I get home to test on Edge/IE. :P