### PR TITLE
edit notifications via CMS, add planning sessions promo

### DIFF
--- a/site/data/notifications.yml
+++ b/site/data/notifications.yml
@@ -1,0 +1,9 @@
+notifications:
+  - loud: true
+    message: >-
+      Join us on Google Hangouts for open, bi-weekly development planning
+      sessions starting Wednesday, July 5th, 11am-12pm ET!
+    published: false
+    title: Netlify CMS Planning Sessions Promo
+    url: >-
+      https://www.eventbrite.com/e/netlify-cms-planning-session-bi-weekly-tickets-35794059997

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -18,6 +18,13 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
   </head>
   <body>
+    {{ range .Site.Data.notifications }}
+      {{ range . }}
+        {{ if .published }}
+          <a href="{{ .url }}" class="notification {{ if .loud }}notification-loud{{end}}">{{ .message }}</a>
+        {{ end }}
+      {{ end }}
+    {{ end }}
     <header id="header" {{ if or (eq .Section "docs") (eq .Title "Docs") }}class="docs"{{ end }}>
       <div class="contained">
         <a href="/" class="logo"><img src="/img/netlify-cms-logo.svg"/></a>

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -17,3 +17,20 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Title", name: "title", widget: "string", tagname: "h1"}
       - {label: "Position", name: "position", widget: "number"}
       - {label: "Body", name: "body", widget: "markdown"}
+  - name: notifications
+    label: Notifications
+    files:
+      - name: notifications
+        label: Notifications
+        file: site/data/notifications.yml
+        description: Site-top notifications - publish one at a time
+        fields:
+          - name: notifications
+            label: Notifications
+            widget: list
+            fields:
+              - {label: Title, name: title, widget: string, tagname: h1}
+              - {label: Published, name: published, widget: boolean}
+              - {label: Loud, name: loud, widget: boolean}
+              - {label: Message, name: message, widget: text}
+              - {label: URL, name: url}

--- a/src/css/imports/header.css
+++ b/src/css/imports/header.css
@@ -30,8 +30,17 @@
     color: $green;
   }
 
+  &.notification-loud {
+    background-color: $green;
+    color: $darkerGrey;
+  }
+
   + header {
-    margin-top: 74px;
+    margin-top: 100px;
+
+    @media screen and (min-width: 360px) {
+      margin-top: 74px;
+    }
 
     @media screen and (min-width: 712px) {
       margin-top: 50px;
@@ -41,8 +50,12 @@
     + .hero:before {
       content: '';
       display: block;
-      height: 74px;
+      height: 100px;
       width: 100%;
+
+      @media screen and (min-width: 360px) {
+        height: 74px;
+      }
 
       @media screen and (min-width: 712px) {
         height: 50px;


### PR DESCRIPTION
* Notifications can be added/edited in the CMS
* Each entry in the list has a "published" switch - allows entries to remain and be toggled on/off
* Added "loud" styling, also toggle-able
* Slight improvement to mobile styling
* Added a promo notification for planning sessions