### PR TITLE
Reduce table padding; make code spans clearer

### DIFF
--- a/src/css/imports/docs.css
+++ b/src/css/imports/docs.css
@@ -152,6 +152,7 @@
     pre > code {
       background: initial;
       padding: initial;
+      white-space: inherit;
     }
 	}
 

--- a/src/css/imports/docs.css
+++ b/src/css/imports/docs.css
@@ -147,8 +147,8 @@
       border-radius: 2px;
       padding: 2px 6px;
       white-space: nowrap;
-    }
-
+    }    
+    
     pre > code {
       background: initial;
       padding: initial;
@@ -201,7 +201,6 @@
 		th,
 		td {
 			padding: 0 $micro;
-      }
 		}
 
 		th {

--- a/src/css/imports/docs.css
+++ b/src/css/imports/docs.css
@@ -142,10 +142,16 @@
       border-radius: $borderRadius;
     }
 
-    p > code {
+    code {
       background: $lightestGrey;
       border-radius: 2px;
       padding: 2px 6px;
+      white-space: nowrap;
+    }
+
+    pre > code {
+      background: initial;
+      padding: initial;
     }
 	}
 
@@ -195,9 +201,6 @@
 		th,
 		td {
 			padding: 0 $micro;
-
-      @media screen and (min-width: $mobile) {
-        padding: 0 $small;
       }
 		}
 

--- a/src/css/imports/docs.css
+++ b/src/css/imports/docs.css
@@ -201,14 +201,12 @@
 
 		th,
 		td {
-			padding: 0 $micro;
+			padding: $micro;
 		}
 
 		th {
-			text-transform: uppercase;
 			font-size: 18px;
 			font-weight: $bold;
-			height: 60px;
 		}
 
 		tbody tr {
@@ -219,7 +217,6 @@
 
 		td {
 			font-size: 14px;
-			height: 46px;
 		}
 	}
 }


### PR DESCRIPTION
The `nowrap` setting could potentially cause issues for really long code spans, but generally speaking, I think the clarity benefits of not having code spans break over lines outweigh this.